### PR TITLE
Delete at-sign check which makes the non-email logins fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:latest
 
-RUN git clone https://github.com/mpepping/safaribooks.git /safaribooks
+COPY . /safaribooks
 
 WORKDIR /safaribooks
 

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -447,9 +447,6 @@ class SafariBooks:
         sep = cred.index(":")
         new_cred = ["", ""]
         new_cred[0] = cred[:sep].strip("'").strip('"')
-        if "@" not in new_cred[0]:
-            return False
-
         new_cred[1] = cred[sep + 1:]
         return new_cred
 


### PR DESCRIPTION
New O'Reilly logins are not emails, so at-sign check makes the login fail.